### PR TITLE
MVP closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["cdylib"]
 seed = "^0.4.0"
 wasm-bindgen = "^0.2.45"
 web-sys = "^0.3.19"
-lazy_static = "*"
 semval = "*"
 
 # For serialization, eg sending requests to a server. Otherwise, not required.

--- a/index.html
+++ b/index.html
@@ -24,20 +24,20 @@
         <script type="module">
             // https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
             import init from '/pkg/package.js';
-            import { get_map_entries, update_bbox, marker_clicked } from '/pkg/package.js';
+            import { start, BBox } from '/pkg/package.js';
             console.log("init wasm");
             init('/pkg/package_bg.wasm').then((res,err) => {
+              const [marker_clicked, update_bbox] = start();
+              window.marker_clicked = marker_clicked;
+              window.update_bbox = update_bbox;
               updateBbox();
             });
-            window.get_map_entries = get_map_entries;
-            window.update_bbox = update_bbox;
-            window.marker_clicked = marker_clicked;
+            window.BBox = BBox;
         </script>
         <script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
    integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
    crossorigin=""></script>
     <script>
-
       var token = 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw';
       var map = L.map('map').setView([48.0, 8.0],8)
       L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
@@ -61,18 +61,17 @@
         let bounds = map.getBounds();
         let ne = bounds.getNorthEast();
         let sw = bounds.getSouthWest();
-        update_bbox(ne.lat, ne.lng, sw.lat, sw.lng);
+        update_bbox(new BBox(sw.lat, sw.lng, ne.lat, ne.lng));
       };
 
-      var updateMap = () => {
-        var entries = get_map_entries();
+      var updateMap = (entries) => {
         console.log("Got entries", entries);
         markers.clearLayers();
         entries
           //.map(e => L.marker([e.lat, e.lng]))
           .forEach(e => {
             let m = L.marker([e.lat, e.lng]);
-            m.bindPopup(e.name);
+            m.bindPopup(e.title);
             m.on('click',()=>{marker_clicked(e.id);})
             m.addTo(markers);
           });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,41 @@
 #[macro_use]
 extern crate seed;
 use futures::Future;
-use lazy_static::lazy_static;
 use seed::prelude::*;
 use semval::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::sync::RwLock;
-
-lazy_static! {
-    static ref MAP_ENTRIES: RwLock<Vec<MapEntry>> = RwLock::new(vec![]);
-}
+use wasm_bindgen::JsValue;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct MapEntry {
+pub struct MapEntry {
     id: String,
     name: String,
     lat: f64,
     lng: f64,
 }
 
+#[wasm_bindgen]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-struct BBox {
-    north_east: LatLng,
-    south_west: LatLng,
+pub struct BBox {
+    pub north_east: LatLng,
+    pub south_west: LatLng,
 }
 
+#[wasm_bindgen]
 impl BBox {
+    #[wasm_bindgen(constructor)]
+    pub fn new(south_west_lat: f64, south_west_lng: f64, north_east_lat: f64, north_east_lng: f64) -> Self {
+        Self {
+            south_west: LatLng {
+                lat: south_west_lat,
+                lng: south_west_lng
+            },
+            north_east: LatLng {
+                lat: north_east_lat,
+                lng: north_east_lng
+            }
+        }
+    }
     fn to_vec(&self) -> Vec<f64> {
         vec![
             self.south_west.lat,
@@ -36,13 +46,14 @@ impl BBox {
     }
 }
 
+#[wasm_bindgen]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-struct LatLng {
-    lat: f64,
-    lng: f64,
+pub struct LatLng {
+    pub lat: f64,
+    pub lng: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug)]
 struct Model {
     pub cities: Option<Vec<City>>,
     pub bbox: Option<BBox>,
@@ -53,7 +64,7 @@ struct Model {
     pub new_entry_form_errors: Vec<EntryFormInvalidity>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone)]
 struct EntryFormModel {
     title: String,
     description: String,
@@ -174,7 +185,7 @@ fn fetch_entries(bbox: &BBox) -> impl Future<Item = Msg, Error = Msg> {
         .fetch_json_data(|d| Msg::EntrySearchResult(d.map_err(|e| format!("{:#?}", e))))
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 enum Msg {
     CitySearch(String),
     CitySearchResult(Result<Vec<NominatimEntry>, String>),
@@ -187,7 +198,7 @@ enum Msg {
     CreateNewEntry,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 enum EntryFormMsg {
     Title(String),
     Description(String),
@@ -236,20 +247,8 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             error!(format!("Fetch error: {:#?}", fail_reason));
         }
         Msg::EntrySearchResult(Ok(res)) => {
-            let entries = res
-                .visible
-                .iter()
-                .cloned()
-                .map(|e| MapEntry {
-                    id: e.id,
-                    name: e.title,
-                    lat: e.lat,
-                    lng: e.lng,
-                })
-                .collect::<Vec<_>>();
             model.entries = res.visible;
-            (*MAP_ENTRIES.write().unwrap()) = entries;
-            updateMap();
+            updateMap(JsValue::from_serde(&model.entries).unwrap());
         }
         Msg::EntrySearchResult(Err(fail_reason)) => {
             error!(format!("Fetch error: {:#?}", fail_reason));
@@ -334,11 +333,10 @@ fn new_entry_form(m: &EntryFormModel, errors: &[EntryFormInvalidity]) -> Node<Ms
             if let Some(msg) = errors
                 .iter()
                 .filter_map(|i| match i {
-                    EntryFormInvalidity::TitleLength(min, max, actual) => Some(format!(
+                    EntryFormInvalidity::TitleLength(min, _max, actual) => Some(format!(
                         "Title too short: {} characters, minimum: {}",
                         actual.0, min.0
                     )),
-                    _ => None,
                 })
                 .nth(0)
             {
@@ -363,67 +361,47 @@ fn new_entry_form(m: &EntryFormModel, errors: &[EntryFormInvalidity]) -> Node<Ms
     ]
 }
 
-#[wasm_bindgen(start)]
-pub fn render() {
-    seed::App::build(|_, _| Model::default(), update, view)
-        .window_events(window_events)
+#[wasm_bindgen]
+pub fn start() -> Box<[JsValue]> {
+    let app = seed::App::build(|_, _| Model::default(), update, view)
         .finish()
         .run();
+
+    let app_clone = app.clone();
+    let marker_clicked_closure = Closure::new(move |id| {
+        marker_clicked(id, app_clone.clone());
+    });
+    let marker_clicked = marker_clicked_closure.as_ref().clone();
+    marker_clicked_closure.forget();
+
+    let app_clone = app.clone();
+    let update_bbox_closure = Closure::new(move |bbox| {
+        update_bbox(bbox, app_clone.clone());
+    });
+    let update_bbox = update_bbox_closure.as_ref().clone();
+    update_bbox_closure.forget();
+
+    vec![marker_clicked, update_bbox].into_boxed_slice()
 }
 
-fn window_events(model: &Model) -> Vec<seed::events::Listener<Msg>> {
-    let mut result = Vec::new();
-    result.push(seed::events::trigger_update_handler());
-    result
-}
-
-#[wasm_bindgen]
-pub fn get_map_entries() -> JsValue {
-    log!("get map entries");
-    JsValue::from_serde(&*MAP_ENTRIES.read().unwrap()).unwrap()
-}
-
-#[wasm_bindgen]
-pub fn update_bbox(
-    north_east_lat: f64,
-    north_east_lng: f64,
-    south_west_lat: f64,
-    south_west_lng: f64,
-) {
-    log!(
-        "Got bounds from JS: {}{}{}{}",
-        north_east_lat,
-        north_east_lng,
-        south_west_lat,
-        south_west_lng,
-    );
-    let bbox = BBox {
-        north_east: LatLng {
-            lat: north_east_lat,
-            lng: north_east_lng,
-        },
-        south_west: LatLng {
-            lat: south_west_lat,
-            lng: south_west_lng,
-        },
-    };
+fn update_bbox<V: View<Msg> + 'static>(bbox: BBox, app: seed::App<Msg, Model, V>) {
+    log!("Got bounds from JS", bbox);
     log!("update seed app");
     seed::set_timeout(
         Box::new(move || {
-            seed::update(Msg::UpdateBBox(bbox));
+            app.update(Msg::UpdateBBox(bbox));
         }),
         15,
     );
 }
 
-#[wasm_bindgen]
-pub fn marker_clicked(id: String) {
-    log!("marker {}", id);
-    seed::update(Msg::EntrySelected(id));
+fn marker_clicked<V: View<Msg> + 'static>(id: String, app: seed::App<Msg, Model, V>) {
+    log!("marker", id);
+    app.update(Msg::EntrySelected(id));
 }
 
 #[wasm_bindgen]
 extern "C" {
     fn setMapCenter(lat: f64, lng: f64);
-    fn updateMap();
+    fn updateMap(map_entries: JsValue);
 }


### PR DESCRIPTION
- removed global state
- removed `seed::update`
- `updateMap` called with entries

Note:
`Closure::new` isn't in `stable` Rust - I've written it for Seed and allowed to use in user apps, but it's limited, you can't change its signature (like add parameters). Alternative is `Closure::wrap` or switch to `nightly` Rust (Seed is not 100% tested on `nigthly`, e.g. I had to add some type annotations because of it). 

Function `start` should be refactored a little bit in the future.